### PR TITLE
Fix GloryHoleSwallow Details concat multiple paragraphs

### DIFF
--- a/scrapers/GloryHoleSwallow.yml
+++ b/scrapers/GloryHoleSwallow.yml
@@ -10,7 +10,9 @@ xPathScrapers:
       $info: //div[@class='objectInfo']
     scene:
       Title: $info/h1/text()
-      Details: $info/div[@class='content']/p/text()
+      Details:
+        selector: $info/div[@class='content']/p/text()
+        concat: "\n\n"
       Tags:
         Name: $info//p[contains(text(),'Tags')]//a/text()
       Image:


### PR DESCRIPTION
Was previously scraping only the first paragraph of scene description, now all available text will be concatenated, providing a full scene description.